### PR TITLE
log real network error cause

### DIFF
--- a/src/load-remote-schema.js
+++ b/src/load-remote-schema.js
@@ -103,10 +103,12 @@ const createErrorLogLink = ({ uri, name }) => {
     }
 
     if (networkError) {
+      const errorMessage = createErrorMessageFromHtmlResponse(networkError);
+
       Object.assign(networkError, {
-        message: `[Remote Network Error in "${name} (${uri})"]: ${networkError.message}`,
+        message: `[Remote Network Error in "${name} (${uri})"]: ${errorMessage}`,
       });
-      logger.error(networkError.message);
+      logger.error(errorMessage);
     }
   });
 };
@@ -154,6 +156,17 @@ const loadIntrospectionSchema = async (link, linkContext) => {
 
   return rawSchema;
 };
+
+function createErrorMessageFromHtmlResponse (networkError) {
+  let errorMessage = `statusCode: ${networkError.statusCode}, `;
+
+  if (networkError.bodyText) {
+    // Strip HTML tags and break lines
+    errorMessage += networkError.bodyText.replace(/<(?:.)*?>|\r\n|\n|\r/gm, '');
+  }
+
+  return errorMessage;
+}
 
 module.exports = {
   loadRemoteSchema,


### PR DESCRIPTION
**Description:**
When the network is not working, the server responds with the HTML page 'Cannot POST'. The Error handler in Apollo tries to parse this HTML to JSON which causes an error `Unexpected token < in JSON at position 0` which mislead what is the real error cause. This code fixes this issue.

**How to test it**

- Add this branch as a dependency on the red-aggregation-layer
- Change the endpoint ARTICLE_GRAPHQL_ENDPOINT in the red-aggregation-layer in the .env file to wrong one
- Run the red-aggregation-layer (yarn start) and check the error message