### PR TITLE
Fixed deprecated use of "new Buffer()"

### DIFF
--- a/src/logger/log-req-res.js
+++ b/src/logger/log-req-res.js
@@ -6,13 +6,13 @@ function createReqResLog (logger) {
     const chunks = [];
 
     res.write = (...restArgs) => {
-      chunks.push(new Buffer(restArgs[0]));
+      chunks.push(Buffer.from(restArgs[0]));
       oldWrite.apply(res, restArgs);
     };
 
     res.end = (...restArgs) => {
       if (restArgs[0]) {
-        chunks.push(new Buffer(restArgs[0]));
+        chunks.push(Buffer.from(restArgs[0]));
       }
       const body = Buffer.concat(chunks).toString('utf8');
 


### PR DESCRIPTION
https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding