### PR TITLE
Fixed GraphQL errors not being logged

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themis-graphql",
-  "version": "0.3.0-beta.7",
+  "version": "0.3.0-beta.8",
   "description": "GQL Data Aggregation CLI",
   "main": "./src/index.js",
   "module": "./src/index.js",


### PR DESCRIPTION
#### What has changed and why

This PR extends the logger to support calls to `logger.log` with arbitrary objects (e. g. errors) that do not include a `level` property. graphql-tools does this, but apparently it is not supported in the default Winston 3 logger. In case of GraphQL errors, this lead to the the message "invalid logger level: undefined" being printed and the log message being skipped.