### PR TITLE
Work around missing extensions field in remote schema errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themis-graphql",
-  "version": "0.3.0-beta.12",
+  "version": "0.3.0-beta.13",
   "description": "GQL Data Aggregation CLI",
   "main": "./src/index.js",
   "module": "./src/index.js",

--- a/src/load-remote-schema.js
+++ b/src/load-remote-schema.js
@@ -123,7 +123,9 @@ function createErrorPrototypeLink () {
   // Some errors seem to get thrown as plain objects which causes them to be converted into
   // Error objects by graphql-js [1], thereby losing some of their properties (including the
   // error's `extensions`). We can work around that by setting the error prototype manually.
+  // This workaround can be removed once an error handling fix [2] is merged into graphql-tools.
   // [1] https://github.com/graphql/graphql-js/blob/e590dd2/src/execution/execute.js#L720
+  // [2] https://github.com/apollographql/graphql-tools/pull/1048
   return onError(({ graphQLErrors, networkError }) => {
     if (graphQLErrors) {
       graphQLErrors.map(ensureErrorPrototype);

--- a/src/server.logging.test.js
+++ b/src/server.logging.test.js
@@ -104,11 +104,7 @@ describe('Server', () => {
       expect(res.body).toMatchObject(expect.objectContaining(expected));
     });
 
-    // TODO: Activate and update when graphql 14.2 is released
-    // including https://github.com/graphql/graphql-js/pull/1600
-    // and graphql-tools with error handling fix:
-    // https://github.com/apollographql/graphql-tools/pull/1048
-    it.skip('logs remote link graphql errors', async () => {
+    it('logs remote link graphql errors', async () => {
       await spawnCLI([
         path.resolve(__dirname, '../test/data/error'),
       ], {
@@ -136,15 +132,15 @@ describe('Server', () => {
           error: null,
         },
         errors: [{
-          message: expect.stringContaining('[Remote GraphQL Error in "error-remote (http://127.0.0.1:53412/api/graphql)"]'),
-          locations: [{ line: 1, column: 9 }],
+          message: '[Remote GraphQL Error in "error-remote (http://127.0.0.1:53412/api/graphql)"]: resolver error in module',
+          locations: [{ column: 3, line: 2 }],
           path: ['error'],
           extensions: {
             code: 'INTERNAL_SERVER_ERROR',
             exception: {
               errors: [{
-                message: expect.stringContaining('[Remote GraphQL Error in "error-remote (http://127.0.0.1:53412/api/graphql)"]'),
                 locations: [],
+                message: 'resolver error in module',
                 path: ['error'],
               }],
             },
@@ -154,10 +150,10 @@ describe('Server', () => {
 
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining(
-          '[Remote GraphQL Error in "error-remote (http://127.0.0.1:53412/api/graphql)"]'
+          '[Remote GraphQL Error in "error-remote (http://127.0.0.1:53412/api/graphql)"]: resolver error in module'
         )
       );
-      expect(res.body).toMatchObject(expect.objectContaining(expected));
+      expect(res.body).toMatchObject(expected);
     });
 
     it('logs remote link graphql errors (with failing local resolver)', async () => {

--- a/test/config/jest.config.json
+++ b/test/config/jest.config.json
@@ -12,5 +12,5 @@
   "setupFiles": [
     "dotenv/config"
   ],
-  "setupTestFrameworkScriptFile": "./test/framework.js"
+  "setupFilesAfterEnv": ["./test/framework.js"]
 }

--- a/test/data/error-custom/index.js
+++ b/test/data/error-custom/index.js
@@ -1,0 +1,9 @@
+const typeDefs = require('./schema');
+const resolvers = require('./resolvers');
+
+module.exports = {
+  name: 'error-custom',
+  typeDefs,
+  resolvers,
+  mocks: {},
+};

--- a/test/data/error-custom/resolvers.js
+++ b/test/data/error-custom/resolvers.js
@@ -1,0 +1,11 @@
+const { UserInputError } = require('apollo-server-express');
+
+module.exports = {
+  Query: {
+    customError: () => {
+      throw new UserInputError('custom resolver error in module', {
+        invalidArgs: ['foo'],
+      });
+    },
+  },
+};

--- a/test/data/error-custom/schema.js
+++ b/test/data/error-custom/schema.js
@@ -1,0 +1,7 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+  type Query {
+    customError: String
+  }
+`;

--- a/test/data/error-remote-on-delegate/index.js
+++ b/test/data/error-remote-on-delegate/index.js
@@ -1,0 +1,24 @@
+const gql = require('graphql-tag');
+const { delegateToSchema } = require('graphql-tools');
+
+module.exports = {
+  name: 'error-remote-on-delegate',
+  typeDefs: gql`
+    type Query {
+      remoteError: String
+    }
+  `,
+  resolvers: {
+    Query: {
+      remoteError: (_, args, context, info) =>
+        delegateToSchema({
+          schema: context.schemas['error-remote'],
+          operation: 'query',
+          fieldName: 'customError',
+          args,
+          context,
+          info,
+        }),
+    },
+  },
+};


### PR DESCRIPTION
#### What has changed and why

This PR works around a bug in the (largely unmaintained) graphql-tools library that causes some error objects' `extensions` field (and also most other fields) to be removed.