### PR TITLE
uploads prop added to schema validation

### DIFF
--- a/src/validate-config.js
+++ b/src/validate-config.js
@@ -24,6 +24,7 @@ const schema = Joi.object().keys({
   onShutdown: Joi.func().default(() => {}),
   formatError: Joi.func(),
   mergedSchemaTransforms: Joi.array().items(Joi.object()).default([]),
+  uploads: Joi.boolean().default(true),
 });
 
 module.exports = function validateConfig (config, configPath) {


### PR DESCRIPTION
#### What has changed and why

in validate-config.js -> "uploads" prop added as boolean 

In order to use file uploads in Node 14 we need to be able to set "uploads" to false. Otherwise the package "graphql-uploads" will not work properly. Official docs: [official docs](https://www.apollographql.com/docs/apollo-server/data/file-uploads/)

#### Steps needed to ensure the issue has been resolved or how to test the feature

// Insert your text here
